### PR TITLE
implementing branch display in git status mode

### DIFF
--- a/dir.go
+++ b/dir.go
@@ -132,9 +132,11 @@ func newDir(d *os.File) (*dir, error) {
 			}
 		}
 
-		if v.IsDir() {
-			if isGitRepository(v.Name()){
-				f.currentBranch, err = getCurrentBranch(v.Name())
+		if flagVector&flag_D > 0 {
+			if v.IsDir() {
+				if isGitRepository(v.Name()){
+					f.currentBranch, err = getCurrentBranch(v.Name())
+				}
 			}
 		}
 
@@ -276,7 +278,7 @@ func (d *dir) print() *bytes.Buffer {
 		}
 		w.Flush(buf)
 	case flagVector&flag_1 > 0:
-		w := ctw.NewLong(6)
+		w := ctw.NewLong(5)
 		for _, v := range d.files {
 			if flagVector&flag_s > 0 {
 				w.AddRow(getSizeInFormate(v.blocks*512), v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)

--- a/dir.go
+++ b/dir.go
@@ -28,6 +28,9 @@ type file struct {
 	gitStatus string
 	icon      string
 	iconColor string
+
+	isGitDir bool
+	currentBranch string
 }
 
 type dir struct {
@@ -129,6 +132,12 @@ func newDir(d *os.File) (*dir, error) {
 			}
 		}
 
+		if v.IsDir() {
+			if isGitRepository(v.Name()){
+				f.currentBranch, err = getCurrentBranch(v.Name())
+			}
+		}
+
 		t.files = append(t.files, f)
 		if v.IsDir() {
 			t.dirs = append(t.dirs, name+"/")
@@ -188,7 +197,7 @@ func newDir_ArgFiles(files []os.FileInfo) *dir {
 		f.ext = filepath.Ext(name)
 		f.name = name[0 : len(name)-len(f.ext)]
 		f.indicator = getIndicator(v.Mode())
-		f.size = v.Size()
+		f.size = v.Size() 
 		f.modTime = v.ModTime()
 		if long {
 			f.mode = v.Mode().String()
@@ -256,23 +265,23 @@ func (d *dir) print() *bytes.Buffer {
 	buf := bytes.NewBuffer([]byte(""))
 	switch {
 	case flagVector&(flag_l|flag_o|flag_g) > 0:
-		w := ctw.NewLong(9)
+		w := ctw.NewLong(10)
 		for _, v := range d.files {
 			if flagVector&flag_s > 0 {
-				w.AddRow(getSizeInFormate(v.blocks*512), v.mode, v.owner, v.group, getSizeInFormate(v.size), v.modTime.Format(timeFormate), v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow(getSizeInFormate(v.blocks*512), v.mode, v.owner, v.group, getSizeInFormate(v.size), v.modTime.Format(timeFormate), v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			} else {
-				w.AddRow("", v.mode, v.owner, v.group, getSizeInFormate(v.size), v.modTime.Format(timeFormate), v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow("", v.mode, v.owner, v.group, getSizeInFormate(v.size), v.modTime.Format(timeFormate), v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			}
 			w.IconColor(v.iconColor)
 		}
 		w.Flush(buf)
 	case flagVector&flag_1 > 0:
-		w := ctw.NewLong(4)
+		w := ctw.NewLong(6)
 		for _, v := range d.files {
 			if flagVector&flag_s > 0 {
-				w.AddRow(getSizeInFormate(v.blocks*512), v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow(getSizeInFormate(v.blocks*512), v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			} else {
-				w.AddRow("", v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow("", v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			}
 			w.IconColor(v.iconColor)
 		}
@@ -281,9 +290,9 @@ func (d *dir) print() *bytes.Buffer {
 		w := ctw.New(terminalWidth)
 		for _, v := range d.files {
 			if flagVector&flag_s > 0 {
-				w.AddRow(getSizeInFormate(v.blocks*512), v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow(getSizeInFormate(v.blocks*512), v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			} else {
-				w.AddRow("", v.icon, v.name+v.ext+v.indicator, v.gitStatus)
+				w.AddRow("", v.icon, v.name+v.ext+v.indicator, v.gitStatus, v.currentBranch)
 			}
 			w.IconColor(v.iconColor)
 		}

--- a/gitStatus.go
+++ b/gitStatus.go
@@ -7,6 +7,28 @@ import (
 	"github.com/go-git/go-git/v5"
 )
 
+func isGitRepository(dir string) bool {
+	_, err := git.PlainOpen(dir)
+
+	return err == nil
+}
+
+// GetCurrentBranch Returns the current Branch
+func getCurrentBranch(path string) (string, error) {
+	op := git.PlainOpenOptions{DetectDotGit: true}
+	r, err := git.PlainOpenWithOptions(path, &op)
+	if err != nil {
+		return "", err
+	}
+
+	headRef, err := r.Head()
+	if err != nil {
+		return "", err
+	}
+
+	return headRef.Name().Short(), nil
+}
+
 func getRepoStatus(path string) (git.Status, string, error) {
 	op := git.PlainOpenOptions{DetectDotGit: true}
 	r, err := git.PlainOpenWithOptions(path, &op)


### PR DESCRIPTION
I tried to implement the displaying of the current checked out branch of git directory when using `logo-ls` is `-D`:

```
$> logo-ls -lD
...
-rw-rw-r--⠀Tom Morelly⠀morelly_t1⠀9211 ⠀Sep 23 21:44:31⠀ﳑ  ⠀main.go⠀   ⠀
-rw-rw-r--⠀Tom Morelly⠀morelly_t1⠀16079⠀Sep 23 20:57:30⠀  ⠀README.md⠀   ⠀
drwxrwxr-x⠀Tom Morelly⠀morelly_t1⠀4096 ⠀Sep 23 22:09:02⠀  ⠀test/⠀   ⠀
drwxrwxr-x⠀Tom Morelly⠀morelly_t1⠀4096 ⠀Sep 23 22:04:56⠀  ⠀tmp/⠀●  ⠀testbranch
```

unfortunately the icons are now not displays as before:

![imgf](https://i.imgur.com/fO5e670.png)

Maybe u can help me fixing the rendering of the icons?