### PR TITLE
Supported for terminals that do not support 'TIOCGWINSZ'

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/Yash-Handa/logo-ls/internal/sysState"
@@ -220,6 +221,10 @@ func Bootstrap() {
 		// screen width for custom tw
 		w, _, e := terminal.GetSize(int(os.Stdout.Fd()))
 		if e == nil {
+			if w == 0 {
+				// for systems that don’t support ‘TIOCGWINSZ’.
+				w, _ = strconv.Atoi(os.Getenv("COLUMNS"))
+			}
 			sysState.TerminalWidth(w)
 		}
 	}


### PR DESCRIPTION
Not all terminals can use 'TIOCGWINSZ' to get the size of the terminal.

https://github.com/golang/crypto/blob/afb6bcd081ae5258e9449bf8b9af19593c9b261f/ssh/terminal/util.go#L79-L85

That's why I used the "COLUMNNS" variable to get the size when the width is zero.

- before my eshell

<img src="https://user-images.githubusercontent.com/29977786/94799228-c7591980-041d-11eb-825c-ea55a7c8da0e.png" width="300px" />

- after my eshell

![image](https://user-images.githubusercontent.com/29977786/94799341-eeafe680-041d-11eb-8ec0-d5f544d44431.png)
