### PR TITLE
minor mod: Using empty (U+0020) instead of brailEmpty

### DIFF
--- a/internal/ctw/ctw.go
+++ b/internal/ctw/ctw.go
@@ -171,14 +171,14 @@ func (w *CTW) colW(b, e int) [4]int {
 
 func (w *CTW) printCell(buf *bytes.Buffer, i int, cs [4]int) {
 	if cs[0] > 0 {
-		fmt.Fprintf(buf, "%-*s%s", cs[0]-1, w.d[i][0], brailEmpty)
+		fmt.Fprintf(buf, "%-*s%s", cs[0]-1, w.d[i][0], empty)
 	}
 	if w.showIcon {
-		fmt.Fprintf(buf, "%s%1s%s%s", w.ic[i], w.d[i][1], noColor, brailEmpty)
+		fmt.Fprintf(buf, "%s%1s%s%s", w.ic[i], w.d[i][1], noColor, empty)
 	}
 	fmt.Fprintf(buf, "%s%-*s%s", getGitColor(w.d[i][3]), cs[2], w.d[i][2], noColor)
 
 	if cs[3] > 0 {
-		fmt.Fprintf(buf, "%s%s%1s%s", brailEmpty, getGitColor(w.d[i][3]), w.d[i][3], noColor)
+		fmt.Fprintf(buf, "%s%s%1s%s", empty, getGitColor(w.d[i][3]), w.d[i][3], noColor)
 	}
 }

--- a/internal/ctw/longCtw.go
+++ b/internal/ctw/longCtw.go
@@ -60,7 +60,7 @@ func (l *LongCTW) Flush(buf *bytes.Buffer) {
 				continue
 			}
 			if f == false {
-				fmt.Fprintf(buf, "%s", brailEmpty)
+				fmt.Fprintf(buf, "%s", empty)
 			}
 
 			if j == l.cols-2 {

--- a/internal/ctw/utils.go
+++ b/internal/ctw/utils.go
@@ -3,10 +3,10 @@ package ctw
 import "strings"
 
 var (
-	noColor    string = "\033[0m"
-	green      string = "\033[38;2;055;183;021m"
-	brown      string = "\033[38;2;192;154;107m"
-	brailEmpty string = "\u2800"
+	noColor string = "\033[0m"
+	green   string = "\033[38;2;055;183;021m"
+	brown   string = "\033[38;2;192;154;107m"
+	empty   string = "\u0020"
 )
 
 func DisplayColor(b bool) {
@@ -14,12 +14,6 @@ func DisplayColor(b bool) {
 		noColor = ""
 		green = ""
 		brown = ""
-	}
-}
-
-func DisplayBrailEmpty(b bool) {
-	if b == false {
-		brailEmpty = " "
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ func main() {
 	}
 	if api.FlagVector&api.Flag_i > 0 {
 		dir.OpenDirIcon = ""
-		ctw.DisplayBrailEmpty(false)
 	}
 
 	// extract files/dir from arguments


### PR DESCRIPTION
I've been using logo-ls for a while and in some cases white-spaces between icons and file names were rendered as follows.

<img width="921" alt="brailEmpty" src="https://user-images.githubusercontent.com/56071114/159560896-158225a0-b5a0-4083-89c6-8050f34fadf5.png">

I checked out the implementation and noticed that the `U+2800` Braille pattern has been used since commit 1a227b5  as a space character, except for when the `-i` flag is risen. However, I found out that `U+2800` does not act as a proper space in the Unicode standard, according to [this](https://unicode-explorer.com/c/2800) unicode-explorer page.

I replaced `U+2800` with `U+0020`, the standard  [space](https://unicode-explorer.com/c/0020) character. Then, the output was properly rendered on every terminal. 

<img width="906" alt="empty" src="https://user-images.githubusercontent.com/56071114/159562771-7d1ce389-d0df-4c8d-9500-4ac87d96933a.png">

I hope this PR might be helpful and thank you for making logo-ls!

